### PR TITLE
Add support for SK9822 (#344)

### DIFF
--- a/src/internal/DotStarGenericMethod.h
+++ b/src/internal/DotStarGenericMethod.h
@@ -78,7 +78,8 @@ public:
     void Update(bool)
     {
 		const uint8_t startFrame[4] = { 0x00 };
-
+		const uint8_t resetFrame[4] = { 0x00 };
+		
 		_wire.beginTransaction();
 
         // start frame
@@ -86,14 +87,18 @@ public:
         
         // data
 		_wire.transmitBytes(_data, _sizeData);
+
+       // reset frame
+		_wire.transmitBytes(resetFrame, sizeof(resetFrame));
         
         // end frame 
+        
 		// one bit for every two pixels with no less than 1 byte
 		for (size_t endFrameByte = 0; endFrameByte < _sizeEndFrame; endFrameByte++)
 		{
-			_wire.transmitByte(0xff);
+			_wire.transmitByte(0x00);
 		}
-
+		
 		_wire.endTransaction();
     }
 


### PR DESCRIPTION
Adds support for the reset frame of the SK9822 LEDS - should have no impact on APA102

Co-authored-by: feindsender <feindsender@users.noreply.github.com>